### PR TITLE
upgraded the OD source tag version to newer one

### DIFF
--- a/io.github.tomluchowski.OpenDungeonsPlus.yml
+++ b/io.github.tomluchowski.OpenDungeonsPlus.yml
@@ -145,5 +145,5 @@ modules:
     sources:
       - type: git
         url:  https://github.com/tomluchowski/OpenDungeonsPlus
-        tag:  experimental_tag_for_flathub_5
+        tag:  experimental_tag_for_flathub_6
 


### PR DESCRIPTION
Current flathub binary version is broken , it cannot find the OgreUnifiedShader.h file, and it doesn't start the game at all. This patch should allow the binary program of a game be able to find OgreUnifiedShader.h, due to changes in resources.cfg.in ( the file from which resources.cfg is being generated ) .....